### PR TITLE
Schedule url ping with GitHub actions

### DIFF
--- a/.github/workflows/scheduled-ping.yml
+++ b/.github/workflows/scheduled-ping.yml
@@ -1,0 +1,26 @@
+name: Scheduled URL Ping
+
+on:
+  schedule:
+    # Runs every 3 hours
+    - cron: '0 */3 * * *'
+  workflow_dispatch: # Allows manual triggering from GitHub UI
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Ping URL
+        run: |
+          curl -X GET "https://twitter-bot-ten-sigma.vercel.app/api/external/tweet" \
+            -H "User-Agent: GitHub-Actions-Scheduled-Ping" \
+            -w "\nHTTP Status: %{http_code}\n" \
+            -o response.txt
+          
+          echo "Response received:"
+          cat response.txt
+          
+      - name: Check Status
+        run: |
+          echo "Ping completed at $(date)"


### PR DESCRIPTION
Add GitHub Actions workflow to ping a specified URL every 3 hours.

---
<a href="https://cursor.com/background-agent?bcId=bc-957f40f1-b826-4b7e-b31c-90215e7231b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-957f40f1-b826-4b7e-b31c-90215e7231b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

